### PR TITLE
Fix example indentation in events doc

### DIFF
--- a/docs/packaging-an-application/events-and-orchestration.md
+++ b/docs/packaging-an-application/events-and-orchestration.md
@@ -87,11 +87,11 @@ containers:
     publish_events:
     - name: Minecraft Server Started
       trigger: exec
-       args: ["grep", "Done", "/data/logs/latest.log"]
-       subscriptions:
-       - component: Redis
-         container: redis
-         action: start
+      args: ["grep", "Done", "/data/logs/latest.log"]
+      subscriptions:
+      - component: Redis
+        container: redis
+        action: start
 ```
 
 ## Subscribed Events


### PR DESCRIPTION
On lines 90-94, "args:" and everything after in the example was indented.  The actual YAML format should have "args:" at the same level of indentation as the proceeding item.
