### PR TITLE
Fixed indentation in default and value docs

### DIFF
--- a/docs/kb/developer-resources/default-or-value.md
+++ b/docs/kb/developer-resources/default-or-value.md
@@ -34,7 +34,7 @@ cmds:
 - name: host_ip
   cmd: get_my_public_ip_address
   args: []
- - name: generate_random_password_32_char
+- name: generate_random_password_32_char
   cmd: random
   args:
   - "32"


### PR DESCRIPTION
Line 37 was incorrectly indented.  This file change is fixing that issue by aligning Line 37 with the immediately proceeding line.
