### PR TITLE
Update template-functions.md

### DIFF
--- a/docs/packaging-an-application/template-functions.md
+++ b/docs/packaging-an-application/template-functions.md
@@ -115,7 +115,7 @@ Note: `ContainerExposedPortAll`, `HostPrivateIpAddressAll`, `HostPublicIpAddress
 ```go
 func ContainerExposedPort(componentName string, containerName string, internalPort string) string
 ```
-Returns the host's public port mapped to the supplied exposed container port as a string.
+Returns the host's public port mapped to the supplied exposed container port as a string. The containerName string will be the image_name for the container.
 ```yml
 env_vars:
 - name: REDIS_PORT


### PR DESCRIPTION
mentioning the orchestration requirement in the docs for the `ContainerExposedPort` template function.