### PR TITLE
Update template-functions.md to mention the orchestration requirement in the docs for the `ContainerExposedPort` template function.

### DIFF
--- a/docs/packaging-an-application/template-functions.md
+++ b/docs/packaging-an-application/template-functions.md
@@ -75,25 +75,27 @@ ports:
      when: '{{repl ConfigOptionNotEquals "http_enabled" "1" }}'
 ```
 
-## HostPrivateIpAddress
+## HostPrivateIpAddress [*](/packaging-an-application/template-functions/#notes)
 ```go
 func HostPrivateIpAddress(componentName string, containerName string) string
 ```
 Returns Private IP Address of Component as a string.
+
 ```yml
 env_vars:
 - name: REDIS_HOST_PRIVATE
   static_val: '{{repl HostPrivateIpAddress "DB" "redis" }}'
 ```
 
-## HostPrivateIpAddressAll
+## HostPrivateIpAddressAll [*](/packaging-an-application/template-functions/#notes)
 ```go
 func HostPrivateIpAddressAll(componentName string, containerName string) []string
 ```
 Returns host private IP addresses for all instances of a given Component as an array of strings.
+
 Note: `ContainerExposedPortAll`, `HostPrivateIpAddressAll`, `HostPublicIpAddressAll` are guaranteed to return in the same order
 
-## HostPublicIpAddress
+## HostPublicIpAddress [*](/packaging-an-application/template-functions/#notes)
 ```go
 func HostPublicIpAddress(componentName string, containerName string) string
 ```
@@ -104,29 +106,32 @@ env_vars:
   static_val: '{{repl HostPublicIpAddress "DB" "redis" }}'
 ```
 
-## HostPublicIpAddressAll
+## HostPublicIpAddressAll [*](/packaging-an-application/template-functions/#notes)
 ```go
 func HostPublicIpAddressAll(componentName string, containerName string) []string
 ```
 Returns host public IP addresses for all instances of a given Component as an array of strings.
+
 Note: `ContainerExposedPortAll`, `HostPrivateIpAddressAll`, `HostPublicIpAddressAll` are guaranteed to return in the same order
 
-## ContainerExposedPort
+## ContainerExposedPort [*](/packaging-an-application/template-functions/#notes)
 ```go
 func ContainerExposedPort(componentName string, containerName string, internalPort string) string
 ```
 Returns the host's public port mapped to the supplied exposed container port as a string.
+
 ```yml
 env_vars:
 - name: REDIS_PORT
   static_val: '{{repl ContainerExposedPort "DB" "redis" "6379" }}'
 ```
 
-## ContainerExposedPortAll
+## ContainerExposedPortAll [*](/packaging-an-application/template-functions/#notes)
 ```go
 func ContainerExposedPortAll(componentName string, containerName string, internalPort string) string
 ```
 Returns the host public port mapped to the supplied exposed container port for all instances of a given Component as an array of strings.
+
 Note: `ContainerExposedPortAll`, `HostPrivateIpAddressAll`, `HostPublicIpAddressAll` are guaranteed to return in the same order
 
 ## LicenseFieldValue
@@ -410,3 +415,9 @@ env_vars:
 - name: HALF_MAX_USERS
   static_val: '{{repl Div (LicenseFieldValue "maximum_users") 2.0}}'
 ```
+
+## Notes
+
+The containerName argument references the image_name property from the container yaml. 
+
+When referencing another container in a template objejct, you must make sure the referenced container is started firs.      Please see the [Events and Orchestration](/packaging-an-application/events-and-orchestration/) section for more information on rchestrating container startup.


### PR DESCRIPTION
mentioning the orchestration requirement in the docs for the `ContainerExposedPort` template function.