### PR TITLE
Fix HTTPS paths for assets when visiting https://replicated.com/docs/

### DIFF
--- a/site/themes/hugo-material-docs/layouts/partials/drawer.html
+++ b/site/themes/hugo-material-docs/layouts/partials/drawer.html
@@ -3,7 +3,7 @@
     <div class="banner">
       {{ with .Site.Params.logo }}
         <div class="logo">
-          <img src="{{ $.Site.BaseURL }}{{ . }}">
+          <img src="/{{ . }}">
         </div>
       {{ end }}
       <div class="name">

--- a/site/themes/hugo-material-docs/layouts/partials/footer_js.html
+++ b/site/themes/hugo-material-docs/layouts/partials/footer_js.html
@@ -8,7 +8,7 @@
     {{ end }}
     </script>
 
-    <script src="{{ .Site.BaseURL }}javascripts/application.js"></script>
+    <script src="/javascripts/application.js"></script>
     {{ range .Site.Params.custom_js }}
     <script src="{{ . | absURL }}"></script>
     {{ end }}

--- a/site/themes/hugo-material-docs/layouts/partials/head.html
+++ b/site/themes/hugo-material-docs/layouts/partials/head.html
@@ -19,30 +19,30 @@
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
 
-    <link rel="shortcut icon" type="image/x-icon" href="{{ $.Site.BaseURL }}{{ with .Site.Params.favicon }}{{ . }}{{ else }}images/favicon.ico{{ end }}">
-    <link rel="icon" type="image/x-icon" href="{{ $.Site.BaseURL }}{{ with .Site.Params.favicon }}{{ . }}{{ else }}images/favicon.ico{{ end }}">
+    <link rel="shortcut icon" type="image/x-icon" href="/{{ with .Site.Params.favicon }}{{ . }}{{ else }}images/favicon.ico{{ end }}">
+    <link rel="icon" type="image/x-icon" href="/{{ with .Site.Params.favicon }}{{ . }}{{ else }}images/favicon.ico{{ end }}">
 
     <style>
       @font-face {
         font-family: 'Icon';
-        src: url('{{ .Site.BaseURL }}fonts/icon.eot?52m981');
-        src: url('{{ .Site.BaseURL }}fonts/icon.eot?#iefix52m981')
+        src: url('/fonts/icon.eot?52m981');
+        src: url('/fonts/icon.eot?#iefix52m981')
                format('embedded-opentype'),
-             url('{{ .Site.BaseURL }}fonts/icon.woff?52m981')
+             url('/fonts/icon.woff?52m981')
                format('woff'),
-             url('{{ .Site.BaseURL }}fonts/icon.ttf?52m981')
+             url('/fonts/icon.ttf?52m981')
                format('truetype'),
-             url('{{ .Site.BaseURL }}fonts/icon.svg?52m981#icon')
+             url('/fonts/icon.svg?52m981#icon')
                format('svg');
         font-weight: normal;
         font-style: normal;
       }
     </style>
 
-    <link rel="stylesheet" href="{{ .Site.BaseURL }}stylesheets/application.css">
-    <link rel="stylesheet" href="{{ .Site.BaseURL }}stylesheets/temporary.css">
-    <link rel="stylesheet" href="{{ .Site.BaseURL }}stylesheets/palettes.css">
-    <link rel="stylesheet" href="{{ .Site.BaseURL }}stylesheets/swagger.css">
+    <link rel="stylesheet" href="/stylesheets/application.css">
+    <link rel="stylesheet" href="/stylesheets/temporary.css">
+    <link rel="stylesheet" href="/stylesheets/palettes.css">
+    <link rel="stylesheet" href="/stylesheets/swagger.css">
     <link rel="stylesheet" href="/stylesheets/font-awesome.min.css">
 
     {{/* set default values if no custom ones are defined */}}
@@ -59,9 +59,9 @@
     </style>
 
     {{ range .Site.Params.custom_css }}
-    <link rel="stylesheet" href="{{ $.Site.BaseURL }}{{ . }}">
+    <link rel="stylesheet" href="/{{ . }}">
     {{ end }}
-    <script src="{{ .Site.BaseURL }}javascripts/modernizr.js"></script>
+    <script src="/javascripts/modernizr.js"></script>
 
     {{ with .RSSlink }}
     <link href="{{ . }}" rel="alternate" type="application/rss+xml" title="{{ $.Site.Title }}" />


### PR DESCRIPTION
I manually tested this locally using docker-compose.

![image](https://user-images.githubusercontent.com/131620/28084397-7e3e6e80-6646-11e7-8063-b4df9de333ca.png)
