### PR TITLE
Override default font-size for search results container

### DIFF
--- a/site/themes/hugo-material-docs/static/stylesheets/application.css
+++ b/site/themes/hugo-material-docs/static/stylesheets/application.css
@@ -918,6 +918,11 @@ h1 .article .headerlink {
     transform: scale(1);
     opacity: 1
 }
+
+.search .field .ds-dropdown-menu {
+    font-size: 14px;
+}
+
 .results {
     -webkit-transition: opacity .3s .1s, width 0s .4s, height 0s .4s;
     transition: opacity .3s .1s, width 0s .4s, height 0s .4s


### PR DESCRIPTION
The default in the stylesheet is 62.5% for `font-size`, I am explicitly overriding it for the container around the search results.